### PR TITLE
feat: 添加系统托盘支持

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
   "app": {
     "windows": [
       {
+        "label": "main",
         "title": "pulsar",
         "width": 1100,
         "height": 600,

--- a/src/components/layout/MainLayout.vue
+++ b/src/components/layout/MainLayout.vue
@@ -22,7 +22,7 @@ const topButtons = [
 ];
 
 const bottomButtons = [
-  { svg: Settings, onClick: "setting", title: "Settings" },
+  { svg: Settings, onClick: "setting.json", title: "Settings" },
 ];
 </script>
 


### PR DESCRIPTION
- 关闭窗口时最小化到系统托盘而非退出程序
- 左键点击托盘图标可重新显示窗口
- 右键托盘图标显示菜单（显示窗口/退出）
- 为主窗口添加 label: "main" 以支持托盘交互

🤖 Generated with [Claude Code](https://claude.com/claude-code)